### PR TITLE
更新 readme.md中 关于判断是否在微信内置浏览器中打开的api 说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ WeixinApi.ready(function(Api) {
 
 #### 7）、判断当前网页是否在微信内置浏览器中打开
 ```javascript
-WeixinApi.ready(function(Api) {
+
 	// true or false
-	var flag = Api.openInWeixin();
-});
+	var flag = WeixinApi.openInWeixin();
+
 ```
 
 #### 8）、打开扫描二维码


### PR DESCRIPTION
判断微信打开的方法 并不需要在 
WeixinApi.ready(function(Api) {}) 调用 这样也没有意义拉, 更新 说明为:
var flag = WeixinApi.openInWeixin();
